### PR TITLE
Fix “(node) warning: possible EventEmitter memory leak detected. 11 d…

### DIFF
--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -82,19 +82,6 @@ module.exports = (function () {
           return next();
         }
 
-        // If the cache gets disconnected, call next()
-        /* NOTE: The disconnected event is emitted after any redis client completes it's configured max_attempts and delay throttling.
-
-        This will throw a nasty error regarding headers when this occurs along the lines of:
-            Error: Can't set headers after they are sent. 
-              at ServerResponse.OutgoingMessage.setHeader...
-
-           ...but it will allow the request to be completed without blocking.  Subsequent requests pass through as self.connected is false.
-        */
-        self.on('disconnected', function () {
-          return next();
-        });
-
         /** Cache entry name
          *
          *  @type String


### PR DESCRIPTION
…isconnected listeners added.” Issue when more than 10 requests concurrent on route